### PR TITLE
Add Da client file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -901,7 +901,7 @@ dependencies = [
 [[package]]
 name = "bitcoin-da"
 version = "0.1.0"
-source = "git+https://github.com/KasarLabs/da#b6f5c4eb8a929041bac7bb21f67205d91c9555c5"
+source = "git+https://github.com/KasarLabs/da#06ce63bc2ab47417255e66f06a7210b9179ab06d"
 dependencies = [
  "bitcoin",
  "bitcoin_hashes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,6 +291,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
+name = "ark-ec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
+dependencies = [
+ "ark-ff 0.4.2",
+ "ark-poly",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "hashbrown 0.13.2",
+ "itertools",
+ "num-traits 0.2.16",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,6 +391,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-poly"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
+dependencies = [
+ "ark-ff 0.4.2",
+ "ark-serialize 0.4.2",
+ "ark-std 0.4.0",
+ "derivative",
+ "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "ark-secp256k1"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c02e954eaeb4ddb29613fee20840c2bbc85ca4396d53e33837e11905363c5f2"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.4.2",
+ "ark-std 0.4.0",
+]
+
+[[package]]
 name = "ark-serialize"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,7 +431,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-serialize-derive",
- "ark-std",
+ "ark-std 0.4.0",
  "digest 0.10.7",
  "num-bigint",
 ]
@@ -404,6 +445,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-std"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
+dependencies = [
+ "num-traits 0.2.16",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -834,6 +885,75 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
+name = "bitcoin"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e99ff7289b20a7385f66a0feda78af2fc119d28fb56aea8886a9cd0a4abdd75"
+dependencies = [
+ "bech32 0.9.1",
+ "bitcoin-private",
+ "bitcoin_hashes",
+ "hex_lit",
+ "secp256k1 0.27.0",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin-da"
+version = "0.1.0"
+source = "git+https://github.com/KasarLabs/da#b6f5c4eb8a929041bac7bb21f67205d91c9555c5"
+dependencies = [
+ "bitcoin",
+ "bitcoin_hashes",
+ "bitcoincore-rpc",
+ "dotenv",
+ "hex",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin-private"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
+dependencies = [
+ "bitcoin-private",
+ "serde",
+]
+
+[[package]]
+name = "bitcoincore-rpc"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6c0ee9354e3dac217db4cb1dd31941073a87fe53c86bcf3eb2b8bc97f00a08"
+dependencies = [
+ "bitcoin-private",
+ "bitcoincore-rpc-json",
+ "jsonrpc",
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "bitcoincore-rpc-json"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d30ce6f40fb0a2e8d98522796219282504b7a4b14e2b4c26139a7bea6aec6586"
+dependencies = [
+ "bitcoin",
+ "bitcoin-private",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,7 +1091,7 @@ name = "blockifier"
 version = "0.1.0-rc2"
 source = "git+https://github.com/keep-starknet-strange/blockifier?branch=no_std-support-7578442#1042c076ce2b669cad9a20aad2e727b3a94713ac"
 dependencies = [
- "ark-ff",
+ "ark-ff 0.4.2",
  "ark-secp256k1",
  "cached",
  "cairo-felt",
@@ -1316,7 +1436,7 @@ source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-s
 dependencies = [
  "cairo-lang-debug",
  "quote",
- "syn 2.0.28",
+ "syn 2.0.29",
 ]
 
 [[package]]
@@ -1365,8 +1485,8 @@ dependencies = [
  "convert_case 0.6.0",
  "derivative",
  "itertools",
- "lalrpop 0.19.12",
- "lalrpop-util 0.19.12",
+ "lalrpop",
+ "lalrpop-util",
  "num-bigint",
  "num-traits 0.2.16",
  "regex",
@@ -1547,7 +1667,7 @@ version = "2.1.0"
 source = "git+https://github.com/keep-starknet-strange/cairo.git?branch=no_std-support-8bbf530#0e591510d73be8d737b0832dc9215ff409e0ed15"
 dependencies = [
  "ark-ff 0.4.2",
- "ark-std 0.3.0",
+ "ark-std 0.4.0",
  "cairo-felt",
  "cairo-lang-casm",
  "cairo-lang-utils",
@@ -1573,7 +1693,7 @@ source = "git+https://github.com/keep-starknet-strange/cairo-rs?branch=no_std-su
 dependencies = [
  "anyhow",
  "ark-ff 0.4.2",
- "ark-std",
+ "ark-std 0.4.0",
  "bincode 2.0.0-rc.3",
  "bitvec 1.0.1",
  "cairo-felt",
@@ -2797,6 +2917,12 @@ dependencies = [
  "quote",
  "syn 2.0.29",
 ]
+
+[[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "downcast"
@@ -4403,6 +4529,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hex_lit"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
 name = "hexlit"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4716,6 +4848,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indent"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f1a0777d972970f204fdf8ef319f1f4f8459131636d7e3c96c5d59570d0fa6"
+
+[[package]]
 name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4893,6 +5031,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonrpc"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8128f36b47411cd3f044be8c1f5cc0c9e24d1d1bfdc45f0a57897b32513053f2"
+dependencies = [
+ "base64 0.13.1",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -5239,7 +5388,7 @@ dependencies = [
  "ena",
  "is-terminal",
  "itertools",
- "lalrpop-util 0.19.12",
+ "lalrpop-util",
  "petgraph",
  "pico-args",
  "regex",
@@ -5251,50 +5400,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lalrpop"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4081d44f4611b66c6dd725e6de3169f9f63905421e8626fcb86b6a898998b8"
-dependencies = [
- "ascii-canvas",
- "bit-set",
- "diff",
- "ena",
- "is-terminal",
- "itertools",
- "lalrpop-util 0.20.0",
- "petgraph",
- "regex",
- "regex-syntax 0.7.4",
- "string_cache",
- "term",
- "tiny-keccak",
- "unicode-xid",
-]
-
-[[package]]
-name = "lalrpop"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da4081d44f4611b66c6dd725e6de3169f9f63905421e8626fcb86b6a898998b8"
-dependencies = [
- "ascii-canvas",
- "bit-set",
- "diff",
- "ena",
- "is-terminal",
- "itertools",
- "lalrpop-util 0.20.0",
- "petgraph",
- "regex",
- "regex-syntax 0.7.4",
- "string_cache",
- "term",
- "tiny-keccak",
- "unicode-xid",
-]
-
-[[package]]
 name = "lalrpop-util"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5302,12 +5407,6 @@ checksum = "3f35c735096c0293d313e8f2a641627472b83d01b937177fe76e5e2708d31e0d"
 dependencies = [
  "regex",
 ]
-
-[[package]]
-name = "lalrpop-util"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f35c735096c0293d313e8f2a641627472b83d01b937177fe76e5e2708d31e0d"
 
 [[package]]
 name = "lazy_static"
@@ -6156,11 +6255,15 @@ dependencies = [
  "anyhow",
  "async-trait",
  "avail-subxt",
+ "bitcoin",
+ "bitcoin-da",
+ "bitcoincore-rpc",
  "celestia-rpc",
  "celestia-types",
  "clap 4.3.22",
  "ethers",
  "futures",
+ "hex",
  "jsonrpsee 0.18.2",
  "lazy_static",
  "log",
@@ -7552,12 +7655,6 @@ name = "path-clean"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
-
-[[package]]
-name = "path-slash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 
 [[package]]
 name = "path-slash"
@@ -10196,7 +10293,19 @@ version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1629c9c557ef9b293568b338dddfc8208c98a18c59d722a9d53f859d9c9b62"
 dependencies = [
- "secp256k1-sys",
+ "secp256k1-sys 0.6.1",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.8.5",
+ "secp256k1-sys 0.8.1",
+ "serde",
 ]
 
 [[package]]
@@ -10204,6 +10313,15 @@ name = "secp256k1-sys"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
 dependencies = [
  "cc",
 ]
@@ -10654,8 +10772,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c792fe9fae2a2f716846f214ca10d5a1e21133e0bf36cef34bcc4a852467b21"
 dependencies = [
  "itertools",
- "lalrpop 0.20.0",
- "lalrpop-util 0.20.0",
+ "lalrpop",
+ "lalrpop-util",
  "phf",
  "thiserror",
  "unicode-xid",
@@ -10912,7 +11030,7 @@ dependencies = [
  "regex",
  "scale-info",
  "schnorrkel",
- "secp256k1",
+ "secp256k1 0.24.3",
  "secrecy",
  "serde",
  "sp-core-hashing 5.0.0",
@@ -10957,7 +11075,7 @@ dependencies = [
  "regex",
  "scale-info",
  "schnorrkel",
- "secp256k1",
+ "secp256k1 0.24.3",
  "secrecy",
  "serde",
  "sp-core-hashing 9.0.0",
@@ -11002,7 +11120,7 @@ dependencies = [
  "regex",
  "scale-info",
  "schnorrkel",
- "secp256k1",
+ "secp256k1 0.24.3",
  "secrecy",
  "serde",
  "sp-core-hashing 10.0.0",
@@ -11177,7 +11295,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "rustversion",
- "secp256k1",
+ "secp256k1 0.24.3",
  "sp-core 7.0.0",
  "sp-externalities 0.13.0",
  "sp-keystore 0.13.0",
@@ -11204,7 +11322,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "rustversion",
- "secp256k1",
+ "secp256k1 0.24.3",
  "sp-core 21.0.0",
  "sp-externalities 0.19.0",
  "sp-keystore 0.27.0",
@@ -12033,7 +12151,6 @@ dependencies = [
  "once_cell",
  "parity-scale-codec",
  "primitive-types",
- "scale-info",
  "serde",
  "serde_json",
  "starknet-crypto 0.5.1",

--- a/crates/client/data-availability/Cargo.toml
+++ b/crates/client/data-availability/Cargo.toml
@@ -56,3 +56,5 @@ celestia-types = { git = "https://github.com/eigerco/celestia-node-rs" }
 bitcoin = { workspace = true }
 bitcoincore-rpc = { workspace = true }
 hex = "0.4.2"
+bitcoin-da = { git = "https://github.com/KasarLabs/da" }
+

--- a/crates/client/data-availability/Cargo.toml
+++ b/crates/client/data-availability/Cargo.toml
@@ -53,8 +53,8 @@ celestia-rpc = { git = "https://github.com/eigerco/celestia-node-rs" }
 celestia-types = { git = "https://github.com/eigerco/celestia-node-rs" }
 
 # Bitcoin
-bitcoin = { workspace = true }
-bitcoincore-rpc = { workspace = true }
+bitcoin = "0.30.1"
+bitcoincore-rpc = "0.17.0"
 hex = "0.4.2"
 bitcoin-da = { git = "https://github.com/KasarLabs/da" }
 

--- a/crates/client/data-availability/src/bitcoin/config.rs
+++ b/crates/client/data-availability/src/bitcoin/config.rs
@@ -1,6 +1,6 @@
 use std::fs::File;
-use std::path::PathBuf;
 use std::net::IpAddr;
+use std::path::PathBuf;
 
 use serde::Deserialize;
 
@@ -18,13 +18,16 @@ pub struct BitcoinConfig {
     pub user: String,
     #[serde(default = "default_pass")]
     pub pass: String,
+    #[serde(default = "default_mode")]
+    pub mode: DaMode,
     // Add other fields if needed
 }
 
 impl BitcoinConfig {
     pub fn try_from_file(path: &PathBuf) -> Result<Self, String> {
         let file = File::open(path).map_err(|e| format!("error when opening bitcoin config file: {}", e))?;
-        let config: Self = serde_json::from_reader(file).map_err(|e| format!("error when parsing bitcoin config file: {}", e))?;
+        let config: Self =
+            serde_json::from_reader(file).map_err(|e| format!("error when parsing bitcoin config file: {}", e))?;
         config.validate()?;
         Ok(config)
     }
@@ -58,12 +61,12 @@ fn default_pass() -> String {
     DEFAULT_BITCOIN_PASS.to_string()
 }
 
+fn default_mode() -> DaMode {
+    DaMode::default()
+}
+
 impl Default for BitcoinConfig {
     fn default() -> Self {
-        Self {
-            host: default_host(),
-            user: default_user(),
-            pass: default_pass(),
-        }
+        Self { host: default_host(), user: default_user(), pass: default_pass(), mode: default_mode() }
     }
 }

--- a/crates/client/data-availability/src/bitcoin/mod.rs
+++ b/crates/client/data-availability/src/bitcoin/mod.rs
@@ -1,21 +1,80 @@
 pub mod config;
 
 // Bitcoin imports
-use bitcoin::{
-    absolute::LockTime, address::AddressType, amount::Amount, blockdata::script::Builder,
-    hash_types::Txid, key::{PrivateKey, PublicKey}, opcodes, OutPoint, ScriptBuf, Transaction, Witness,
-    Address, Network, TxIn, TxOut, sighash, script::PushBytesBuf,
-};
-use bitcoin::secp256k1::{All, Secp256k1, KeyPair, SecretKey, XOnlyPublicKey};
-use bitcoin::taproot::{LeafVersion, NodeInfo, TapTree, TaprootBuilder};
-use bitcoin::script as txscript;
 
+use anyhow::Result;
+use async_trait::async_trait;
+use bitcoin_da::Config as BitcoinDAConfig;
+// use bitcoin::hash_types::Txid;
+// use bitcoin::key::{PrivateKey, PublicKey};
+// use bitcoin::script::PushBytesBuf;
+// use bitcoin::secp256k1::{All, KeyPair, Secp256k1, SecretKey, XOnlyPublicKey};
+// use bitcoin::taproot::{LeafVersion, NodeInfo, TapTree, TaprootBuilder};
+// use bitcoin::{opcodes, script as txscript, sighash, Network, OutPoint, ScriptBuf, Transaction, TxIn, TxOut,
+// Witness};
+use bitcoin_da::Relayer;
+use bitcoincore_rpc::Client as RpcClient;
 // Bitcoincore RPC imports
 use bitcoincore_rpc::{Auth, Error, RpcApi};
-use bitcoincore_rpc::Client as RpcClient;
+use ethers::types::{I256, U256};
 
-// Standard imports
-use core::fmt;
-use std::str::FromStr;
-
+use crate::utils::is_valid_http_endpoint;
 use crate::{DaClient, DaMode};
+
+// remove with CRV pr
+struct BitcoinConfig {}
+// #[derive(Clone, Debug)]
+pub struct BitcoinClient {
+    relayer: Relayer,
+    mode: DaMode,
+}
+
+#[async_trait]
+impl DaClient for BitcoinClient {
+    async fn publish_state_diff(&self, state_diff: Vec<U256>) -> Result<()> {
+        println!("State diff: {:?}", state_diff);
+
+        // convert state_diff to bytes
+        let mut data = vec![0u8; state_diff.len() * 32]; // data buffer, 32 bytes per u256
+        for (i, value) in state_diff.iter().enumerate() {
+            // iterate over state_diff
+            let start = i * 32;
+            let end = start + 32;
+            value.to_big_endian(&mut data[start..end]);
+        }
+
+        let tx: bitcoin::Txid = self.relayer.write(&data).map_err(|e| anyhow::anyhow!("bitcoin write err: {e}"))?;
+
+        log::info!("State Update: {:?}", tx);
+        Ok(())
+    }
+
+    async fn last_published_state(&self) -> Result<I256> {
+        todo!();
+    }
+
+    fn get_mode(&self) -> DaMode {
+        self.mode
+    }
+}
+
+impl BitcoinClient {
+    pub fn try_from_config(conf: config::BitcoinConfig) -> Result<Self, String> {
+        if !is_valid_http_endpoint(&conf.host) {
+            return Err(format!("invalid http endpoint, received {}", &conf.host));
+        }
+
+        let bitcoin_da_conf: BitcoinDAConfig = BitcoinDAConfig {
+            host: conf.host,
+            user: conf.user,
+            pass: conf.pass,
+            http_post_mode: false,
+            disable_tls: false,
+        };
+
+        let client: Relayer =
+            Relayer::new_relayer(&bitcoin_da_conf).map_err(|e| format!("bitcoin new relayer err: {e}"))?;
+
+        Ok(Self { relayer: client, mode: conf.mode })
+    }
+}

--- a/crates/client/data-availability/src/bitcoin/mod.rs
+++ b/crates/client/data-availability/src/bitcoin/mod.rs
@@ -55,8 +55,7 @@ impl DaClient for BitcoinClient {
 
     async fn last_published_state(&self) -> Result<I256> {
         let last_tx = self.relayer.client.list_transactions("*", 15, None, true)?;
-        // let last_data_raw = self.relayer.read_height(height).map_err(|e| anyhow::anyhow!("bitcoin read
-        // err: {e}"))?;
+
         let filtered_txs: Vec<&ListTransactionResult> =
             last_tx.iter().filter(|tx| tx.detail.category == GetTransactionResultDetailCategory::Send).collect();
         filtered_txs.sort_by(|a, b| a.info.blockheight.cmp(&b.info.blockheight));

--- a/crates/client/data-availability/src/lib.rs
+++ b/crates/client/data-availability/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod avail;
+pub mod bitcoin;
 pub mod celestia;
 pub mod ethereum;
 mod sharp;
@@ -25,6 +26,7 @@ pub struct DataAvailabilityWorker<B, C>(PhantomData<(B, C)>);
 pub enum DaLayer {
     Celestia,
     Ethereum,
+    Bitcoin,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Deserialize, Default)]


### PR DESCRIPTION
Should close issues #3 and #4 

Implemented bitcoin/mod.rs.
Added `mode` member to config struct

There are 3 functions:
- `publish_state_diff`
- `last_published_state`
- ` try_from_config`

`publish_state_diff` is the function where we call bitcoin-da crate and write on Bitcoin. It is also where we serialize the statediff.

`last_published_state` should return the last block height of the rollup

` try_from_config` instantiate a new Client (which includes a Relayer).

This PR is a work in progress. 
Some components still need to be understood. For isntance, I'm not sure if the state diff includes the rollup block height somewhere. It is needed in the ordinals inscription.

Needs issue DA # 45 to be merged. 
